### PR TITLE
Fix for notify when pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,3 +116,4 @@ jobs:
         with:
           teams_webhook_url: ${{ secrets.TEAMS_WEBHOOK_URI }}
           message: "<h1>Checkmarx TeamCity Plugin ${{ env.RELEASE_VERSION }}</h1>${{ steps.clean.outputs.clean }}"
+        if: ${{ inputs.rchannels == '' || inputs.rchannels == null }}


### PR DESCRIPTION
If pre-release CI will not notify

![image](https://github.com/Checkmarx/ast-teamcity-plugin/assets/114568996/1caa7109-df65-44c7-96d5-a5c65f87c593)
