### PR TITLE
fix(actions): declare secrets used by reusable workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,13 @@ on:
         description: 'Channels to publish development releases'
         required: false
         type: string
+    secrets:
+      JETBRAINS_PLUGIN_ID:
+        required: true
+      JETBRAINS_USER:
+        required: true
+      PERSONAL_ACCESS_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Adds explicit on.workflow_call.secrets declarations for all secrets referenced in the workflow body, replacing implicit reliance on callers using secrets: inherit.